### PR TITLE
Adding intake-esm from upstream master

### DIFF
--- a/deployments/ocean/image/binder/environment.yml
+++ b/deployments/ocean/image/binder/environment.yml
@@ -23,4 +23,4 @@ dependencies:
     - git+https://github.com/xgcm/xgcm.git@master
     - git+https://github.com/intake/filesystem_spec.git@master
     - git+https://github.com/dask/gcsfs.git@master
-    - intake-esm
+    - git+https://github.com/NCAR/intake-esm.git


### PR DESCRIPTION
I am using the new `preprocess` functionality quite extensively with [cmip6_preprocessing](https://github.com/jbusecke/cmip6_preprocessing) and I think it would be nice to have this available for the standard environment. 